### PR TITLE
Adding command to create new cli

### DIFF
--- a/devcli.d/_file_manifest
+++ b/devcli.d/_file_manifest
@@ -18,3 +18,20 @@ $(cat <<-EOM
 EOM
 )
 }
+
+function new_cli_files() {
+echo \
+$(cat <<-EOM
+  date
+  docs
+  template
+  tools
+  vcs
+  url
+  _environment
+  _linux_date
+  _git
+  _macos_date
+EOM
+)
+}

--- a/devcli.d/_file_manifest
+++ b/devcli.d/_file_manifest
@@ -28,6 +28,7 @@ $(cat <<-EOM
   tools
   vcs
   url
+  _empty
   _environment
   _linux_date
   _git

--- a/devcli.d/create
+++ b/devcli.d/create
@@ -39,6 +39,7 @@ case ${1} in
     in_cyan "Copying the conf folder\n"
     cp -r "${CONFIGURATION_DIR}" "${new_config_dir}"
     rm -rf "${new_config_dir}/twin"
+    rm -rf "${new_config_dir}/ci"
 
     new_files_to_copy=$(new_cli_files)
     log "functionalities to copy: ${new_files_to_copy}"

--- a/devcli.d/create
+++ b/devcli.d/create
@@ -1,0 +1,61 @@
+# vim: ft=sh sw=2 ts=2 expandtab
+use "file_manifest"
+
+SUBCOMMAND_DESC="Utility to create new copies of'${MAIN_COMMAND}'"
+SUBCOMMAND_HELP=$(cat <<EOH
+
+new_cli DIR [NAME]         This will create a new CLI
+
+EOH
+)
+
+case ${1} in
+  new_cli)
+    new_dir="${2?'missing new command DIR parameter'}"
+    [[ ! -d "${new_dir}" ]] \
+      && error "'${new_dir}' must be a directory.\n"
+
+    new_cli_name="${3-${config['name']}}"
+    [[ -n ${new_cli_name} ]] || error "NAME not found in twin/conf or given as argument"
+
+    new_cli_name="${new_cli_name,,}" # make it lowercase
+    in_cyan "Creating '${new_cli_name}' as a new copy of this tool\n"
+
+    new_project_dir="${new_dir%/}/${new_cli_name}"
+    log "project dir set as: ${new_project_dir}"
+    [[ -d "${new_project_dir}" ]] \
+      && error "${new_project_dir} already exists, choose another name\n"
+
+    new_subcmd_dir="${new_project_dir}/${new_cli_name}.d"
+    new_config_dir="${new_project_dir}/conf"
+    log "subcmd dir set as: ${new_subcmd_dir}"
+    log "config dir set as: ${new_config_dir}"
+
+    in_cyan "Creating directory: ${new_project_dir}\n"
+    mkdir "${new_project_dir}"
+    in_cyan "Creating subcmd directory: ${new_subcmd_dir}\n"
+    mkdir "${new_subcmd_dir}"
+
+    in_cyan "Copying the conf folder\n"
+    cp -r "${CONFIGURATION_DIR}" "${new_config_dir}"
+    rm -rf "${new_config_dir}/twin"
+
+    new_files_to_copy=$(new_cli_files)
+    log "functionalities to copy: ${new_files_to_copy}"
+    
+    in_cyan "Copying the default functionalities \n"
+    cd "${SUBCOMMANDS_DIR}"
+    cp -r ${new_files_to_copy} "${ROOT_DIR}/${new_subcmd_dir}"
+    cd "${ROOT_DIR}"
+
+    in_cyan "Copying the devcli executable\n"
+    cp "${ROOT_DIR}/${MAIN_COMMAND}" "${new_project_dir}/${new_cli_name}"
+
+
+    in_cyan "Exporting configuration environment variables for '${new_cli_name}'\n"
+    export "${new_cli_name^^}_CONF_DIR=${new_config_dir}"
+    export "${new_cli_name^^}_SUBCMD_DIR=${new_subcmd_dir}"
+
+    in_green "${new_cli_name} setup finished.\n"
+  ;;
+esac


### PR DESCRIPTION
I created a new command that creates a new CLI with just some basic funcionalities in order to make it easy for people that are new to shell or unix to start using this CLI.

The current twin functionality is either too complex for two reasons:

1. Uses symbolic link, which requires people to have the original CLI and the new one, sharing the same executable. Can be very confusing for beginners
2. Although the twin can copy itself as well, the original CLI has too many functionalities, which requires people to delete lots of them and could be confusing as well.

